### PR TITLE
Revamp pipeline that loads raw realtime vehicle position CSV files from GCS to BQ

### DIFF
--- a/dags/load_realtime_to_bq.py
+++ b/dags/load_realtime_to_bq.py
@@ -57,7 +57,7 @@ with DAG(
     "load_realtime_miway_data_to_bq",
     default_args=default_args,
     description="Loads realtime vehicle location data from GCS to BigQuery",
-    schedule_interval=timedelta(minutes=10),
+    schedule_interval=timedelta(minutes=90),
     start_date=datetime(2024, 1, 1),
     catchup=False,
     tags=["miway"],

--- a/dags/sql/merge_stage_raw_vehicle_position.sql
+++ b/dags/sql/merge_stage_raw_vehicle_position.sql
@@ -1,0 +1,53 @@
+MERGE `{{ params.project_id }}.{{ params.dataset_id }}.{{ params.vehicle_table_name }}` AS target
+USING `{{ params.project_id }}.{{ params.dataset_id }}.{{ params.stage_vehicle_table_name }}` AS source
+ON target.vehicle_id = source.vehicle_id
+AND target.timestamp = source.timestamp
+AND target.trip_id = source.trip_id
+WHEN MATCHED THEN
+    UPDATE SET
+        target.id = source.id
+        ,target.trip_id = source.trip_id
+        ,target.route_id = source.route_id
+        ,target.direction_id = source.direction_id
+        ,target.start_date = source.start_date
+        ,target.vehicle_id = source.vehicle_id
+        ,target.vehicle_label = source.vehicle_label
+        ,target.latitude = source.latitude
+        ,target.longitude = source.longitude
+        ,target.bearing = source.bearing
+        ,target.speed = source.speed
+        ,target.timestamp = TIMESTAMP_SECONDS(source.timestamp)
+        ,target.occupancy_status = source.occupancy_status
+        ,target.occupancy_percentage = source.occupancy_percentage
+WHEN NOT MATCHED THEN
+    INSERT (
+        id
+        ,trip_id
+        ,route_id
+        ,direction_id
+        ,start_date
+        ,vehicle_id
+        ,vehicle_label
+        ,latitude
+        ,longitude
+        ,bearing
+        ,speed
+        ,timestamp
+        ,occupancy_status
+        ,occupancy_percentage
+    ) VALUES (
+        source.id
+        ,source.trip_id
+        ,source.route_id
+        ,source.direction_id
+        ,source.start_date
+        ,source.vehicle_id
+        ,source.vehicle_label
+        ,source.latitude
+        ,source.longitude
+        ,source.bearing
+        ,source.speed
+        ,TIMESTAMP_SECONDS(source.timestamp)
+        ,source.occupancy_status
+        ,source.occupancy_percentage
+    );

--- a/dags/sql/setup/create_vehicle_position_tables.sql
+++ b/dags/sql/setup/create_vehicle_position_tables.sql
@@ -1,3 +1,9 @@
+/*
+  The final raw vehicle location table is partitioned by day from timestamp.
+  It requires a small transformation from staging to final table.
+  Therefore, we have two CREATE TABLE statements here.
+*/
+
 CREATE TABLE raw_miway_data.vehicle_position
 (
   id STRING OPTIONS (
@@ -33,7 +39,7 @@ CREATE TABLE raw_miway_data.vehicle_position
   speed FLOAT64 OPTIONS (
     description="Instantaneous speed of the vehicle in meters per second"
   ),
-  timestamp INT64 OPTIONS (
+  timestamp TIMESTAMP OPTIONS (
     description="Timestamp of the vehicle location update in Unix epoch time (seconds since January 1, 1970)"
   ),
   occupancy_status INT OPTIONS (
@@ -43,12 +49,13 @@ CREATE TABLE raw_miway_data.vehicle_position
     description="Occupancy percentage of the vehicle, as defined in the GTFS Realtime specification"
   )
 )
-PARTITION BY _PARTITIONDATE
+PARTITION BY DATE(timestamp)
 OPTIONS(
-  description="A table that contains vehicle positions."
+  description="A table that contains vehicle positions, partitioned by the date extracted from the timestamp.",
+  partition_expiration_days=30
 );
 
-/* Almost the same as the raw table, but without partitioning as data only stored for a short time*/
+
 CREATE TABLE raw_miway_data.stage_vehicle_position
 (
   id STRING OPTIONS (
@@ -95,5 +102,6 @@ CREATE TABLE raw_miway_data.stage_vehicle_position
   )
 )
 OPTIONS(
-  description="A stage table that contains vehicle positions to be transferred to the main table."
+  description="A temporary table that contains vehicle positions.",
 );
+


### PR DESCRIPTION
- Use DATE from timestamp for partitioning raw vehicle positions tables, set partition expiry to 30 days;
- Put merge query from Python to standalone SQL file for better visibility.

closes #12 #14